### PR TITLE
Fix label for docs of GdbStartPDB

### DIFF
--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -56,7 +56,7 @@ Section 2: Commands                                          *NvimgdbCommands*
 :GdbStartLLDB [cmd]     Start debugging session with the given LLDB launch
                         command.
 
-                                                               *:GdbStartLLDB*
+                                                               *:GdbStartPDB*
 :GdbStartPDB [cmd]      Start Python debugging session with the given PDB
                         launch command.
 


### PR DESCRIPTION
There is a typo which causes an error when running helptags. 