### PR TITLE
Don't send breakpoints from lldb_command for symbols without sources

### DIFF
--- a/lib/lldb_commands.py
+++ b/lib/lldb_commands.py
@@ -23,8 +23,10 @@ def _GetBreaks(fname):
         for loc in breakpoint:
             lineentry = loc.GetAddress().GetLineEntry()
             filespec = lineentry.GetFileSpec()
-            path = os.path.join(filespec.GetDirectory(),
-                                filespec.GetFilename())
+            filename = filespec.GetFilename()
+            if not filename:
+                continue
+            path = os.path.join(filespec.GetDirectory(), filename)
 
             # See whether the breakpoint is in the file in question
             if fname == path:


### PR DESCRIPTION
lib/lldb_commands.py:_GetBreaks iterates over all found breakpoints
and checks the filename of it. However, lldb will set breakpoints in
targets with symbol information but no sources and thus the code
tries to call functions on `None`.

Break out of the inner loop if there is no filename corresponding to
the breakpoint