### PR TITLE
Changed GdbKill() for 'set hidden' compatibility

### DIFF
--- a/autoload/nvimgdb.vim
+++ b/autoload/nvimgdb.vim
@@ -5,6 +5,7 @@ lua gdb = require("gdb.app")
 
 
 function! s:GdbKill()
+  " prevent "ghost" [noname] buffers when leaving debug when 'hidden' is on
   if &hidden
     set nohidden
     let l:hidden = 1
@@ -20,6 +21,7 @@ function! s:GdbKill()
   " TabEnter isn't fired automatically when a tab is closed
   lua gdb.tabEnter()
 
+  " sets hidden back to user default
   if l:hidden
     set hidden
   endif

--- a/autoload/nvimgdb.vim
+++ b/autoload/nvimgdb.vim
@@ -5,6 +5,13 @@ lua gdb = require("gdb.app")
 
 
 function! s:GdbKill()
+  if &hidden
+    set nohidden
+    let l:hidden = 1
+  else
+    let l:hidden = 0
+  endif
+
   " Cleanup commands, autocommands etc
   call nvimgdb#ui#Leave()
 
@@ -12,6 +19,10 @@ function! s:GdbKill()
 
   " TabEnter isn't fired automatically when a tab is closed
   lua gdb.tabEnter()
+
+  if l:hidden
+    set hidden
+  endif
 endfunction
 
 


### PR DESCRIPTION
Changed the function GdbKill() for compatibility reasons with "set hidden" .vimrc option.
issue #48 can be closed