### PR TITLE
Change lldb evaluations to use frame var instead of expr

### DIFF
--- a/lua/gdb/backend/lldb.moon
+++ b/lua/gdb/backend/lldb.moon
@@ -39,6 +39,7 @@ backend =
     initScm: LldbScm
     delete_breakpoints: 'breakpoint delete'
     breakpoint: 'b'
+    'print %s': 'frame var %s'
     'until %s': 'thread until %s'
 
 backend


### PR DESCRIPTION
The expression command jits the code, injects it into the address
space of the inferior process, and evaluates it. This sometimes takes
a ridiculous amount of time. The `frame variable` command uses debug
info avaialble and loaded to calculate the value of the variables
you're looking for before and is always much faster than expr.