### PR TITLE
Add a check to remove tab-persistant windows and a split/vertical option

### DIFF
--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -159,7 +159,8 @@ allows overriding the given keys. For example, the default config is: >
       \ 'set_keymaps':    'function("GdbCallAsync", "keymaps.set")',
       \ 'unset_keymaps':  'function("GdbCallAsync", "keymaps.unset")',
       \ 'sign_current_line': '▶',
-      \ 'sign_breakpoint': [ '●', '●²', '●³', '●⁴', '●⁵', '●⁶', '●⁷', '●⁸', '●⁹', '●ⁿ' ]
+      \ 'sign_breakpoint': [ '●', '●²', '●³', '●⁴', '●⁵', '●⁶', '●⁷', '●⁸', '●⁹', '●ⁿ' ],
+      \ 'split_orientation': 'horizontal'
       \ }
 <
 The keys starting with `sign_` define how the signs for the currently executed

--- a/rplugin/python3/gdb/app.py
+++ b/rplugin/python3/gdb/app.py
@@ -14,16 +14,21 @@ class App:
     def __init__(self, vim, backendStr, proxyCmd, clientCmd):
         self.vim = vim
 
+        # Prepare configuration: keymaps, hooks, parameters etc.
+        self.config = getConfig(vim)
+        self.defineSigns(self.config)
+
         # Create new tab for the debugging view and split horizontally
-        vim.command("tabnew | sp")
+        cmd = "tabnew | setlocal nowinfixwidth | setlocal nowinfixheight | exe \"normal \<c-w>o\" | "
+        if self.config["split_orientation"] == 'vertical':
+            cmd += "vs"
+        else:
+            cmd += "split"
+        vim.command(cmd)
 
         # Enumerate the available windows
         wins = vim.current.tabpage.windows
         wcli, wjump = wins[1], wins[0]
-
-        # Prepare configuration: keymaps, hooks, parameters etc.
-        self.config = getConfig(vim)
-        self.defineSigns(self.config)
 
         # Import the desired backend module
         self.backend = importlib.import_module("gdb.backend." + backendStr).init()

--- a/rplugin/python3/gdb/config.py
+++ b/rplugin/python3/gdb/config.py
@@ -31,6 +31,7 @@ def getConfig(vim):
         'unset_keymaps': Keymaps.unset,
         'sign_current_line': '▶',
         'sign_breakpoint': [ '●', '●²', '●³', '●⁴', '●⁵', '●⁶', '●⁷', '●⁸', '●⁹', '●ⁿ' ],
+        'split_orientation': 'horizontal'
         }
 
     # Make a copy of the supplied configuration if defined


### PR DESCRIPTION
Plugins such as nerdtree-tabs persist windows automatically on every
pane. So the call to `tabnew | split` would be interfered with via
this automatic second window. So upon opening nvim-gdb we should
clear the fixed settings for these windows and close all others.

Also, add an option to have either horizontal or vertical splits for
the two default windows.