### PR TITLE
Add an option to disable the usage of scrolloff

### DIFF
--- a/rplugin/python3/gdb/app.py
+++ b/rplugin/python3/gdb/app.py
@@ -145,7 +145,9 @@ class App:
     def onBufEnter(self):
         if self.vim.current.buffer.options['buftype'] != 'terminal':
             # Make sure the cursor stay visible at all times
-            self.vim.command("if !&scrolloff | setlocal scrolloff=5 | endif")
+
+            if "set_scroll_off" in self.config:
+                self.vim.command("if !&scrolloff | setlocal scrolloff=%s | endif" % str(self.config['set_scroll_off']))
             self.keymaps.dispatchSet()
             # Ensure breakpoints are shown if are queried dynamically
             self.win.queryBreakpoints()

--- a/rplugin/python3/gdb/config.py
+++ b/rplugin/python3/gdb/config.py
@@ -32,6 +32,7 @@ def getConfig(vim):
         'sign_current_line': '▶',
         'sign_breakpoint': [ '●', '●²', '●³', '●⁴', '●⁵', '●⁶', '●⁷', '●⁸', '●⁹', '●ⁿ' ],
         'split_command': 'split',
+        'set_scroll_off': 5
         }
 
     # Make a copy of the supplied configuration if defined
@@ -44,7 +45,7 @@ def getConfig(vim):
             except:
                 pass
         # Make sure the essential keys are present even if not supplied.
-        for mustHave in ('sign_current_line', 'sign_breakpoint', 'split_command'):
+        for mustHave in ('sign_current_line', 'sign_breakpoint', 'split_command', 'set_scroll_off'):
             if not mustHave in config:
                 config[mustHave] = defaultConfig[mustHave]
 


### PR DESCRIPTION
Scrolloff has clumsy behavior at times while using the neovim terminal
emulator. Allow it to be disabled with the default behavior to use
the previous `setlocal scrolloff=5` behavior.