### PR TITLE
Changed invocation of gdbproxy.py to eval in gdbwrap.sh

### DIFF
--- a/lib/gdbwrap.sh
+++ b/lib/gdbwrap.sh
@@ -37,4 +37,4 @@ cleanup()
 trap cleanup EXIT
 
 # Execute gdb finally through the proxy with our custom initialization script
-"$this_dir/gdbproxy.py" -a $server_addr -- "$gdb" -f -ix $gdb_init $rest
+eval "$this_dir/gdbproxy.py" -a $server_addr -- "$gdb" -f -ix $gdb_init $rest


### PR DESCRIPTION
This way, we can pass complex arguments with quotes.
Before, there would be an error as the arguments would be parsed wrongly.

This is relevant for passing complex arguments to gdb with quotes like `gdb -ex 'break main'`. Using eval, bash will interpret correctly the quotes.