### PR TITLE
Add more autocmds

### DIFF
--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -224,6 +224,15 @@ NvimGdbQuery            Fired whenever the plugin queried for breakpoints.
                         This can be used to execute additional queries
                         with `GdbCustomCommand()`
 
+NvimGdbBreak            Fired whenever the programm is paused.
+
+NvimGdbContinue         Fired whenever the program is resumed after it has
+                        been paused.
+
+NvimGdbStart            Fired when the debugging session starts.
+
+NvimGdbCleanup          Fired before the debugging session ends.
+
 ==============================================================================
 Section 6: Functions                                        *NvimgdbFunctions*
 

--- a/rplugin/python3/gdb/app.py
+++ b/rplugin/python3/gdb/app.py
@@ -74,9 +74,12 @@ class App:
     def start(self):
         '''The SCM should be ready by now, spawn the debugger!'''
         self.client.start()
+        self.vim.command("doautocmd User NvimGdbStart")
 
     def cleanup(self):
         '''Finish up the debugging session.'''
+        self.vim.command("doautocmd User NvimGdbCleanup")
+
         # Clean up the breakpoint signs
         self.breakpoint.reset_signs()
 

--- a/rplugin/python3/gdb/scm.py
+++ b/rplugin/python3/gdb/scm.py
@@ -36,6 +36,9 @@ class BaseScm:
     def _paused_continue(self, _):
         self.log("_paused_continue")
         self.cursor.hide()
+
+        self.vim.command("doautocmd User NvimGdbContinue")
+
         return self.running
 
     def _paused_jump(self, match):
@@ -43,11 +46,18 @@ class BaseScm:
         line = match.group(2)
         self.log(f"_paused_jump {fname}:{line}")
         self.win.jump(fname, int(line))
+
+        self.vim.command("doautocmd User NvimGdbBreak")
+
         return self.paused
 
     def _query_b(self, _):
         self.log('_query_b')
         self.win.query_breakpoints()
+
+        # Execute the rest of custom commands
+        self.vim.command("doautocmd User NvimGdbQuery")
+
         return self.paused
 
     def _search(self):

--- a/rplugin/python3/gdb/win.py
+++ b/rplugin/python3/gdb/win.py
@@ -63,6 +63,3 @@ class Win:
             # If there was a cursor, make sure it stays above the breakpoints.
             self.cursor.reshow()
             self.vim.command("redraw")
-
-        # Execute the rest of custom commands
-        self.vim.command("doautocmd User NvimGdbQuery")


### PR DESCRIPTION
I used nvim's virtual text feature to show the values of local variables inline in the buffer (if you're interested, I can do a PR but I only have lldb support). But for that I needed more autocmds.