### PR TITLE
Explicitly initialize individual backends instead of relying on importlib and implicit behavior

### DIFF
--- a/rplugin/python3/gdb/backend/bashdb.py
+++ b/rplugin/python3/gdb/backend/bashdb.py
@@ -18,13 +18,11 @@ class BashDBParser(Parser):
         self.add_trans(self.paused, re_term, self._handle_terminated)
         self.state = self.paused
 
+        self.command_map = {
+            'delete_breakpoints': 'delete',
+            'breakpoint': 'break'
+        }
+
     def _handle_terminated(self, _):
         self.cursor.hide()
         return self.paused
-
-
-def init():
-    '''Initialize the backend.'''
-    return {'initParser': BashDBParser,
-            'delete_breakpoints': 'delete',
-            'breakpoint': 'break'}

--- a/rplugin/python3/gdb/backend/gdb.py
+++ b/rplugin/python3/gdb/backend/gdb.py
@@ -25,9 +25,7 @@ class GdbParser(Parser):
 
         self.state = self.running
 
-
-def init():
-    '''Initialize the backend.'''
-    return {'initParser': GdbParser,
+        self.command_map = {
             'delete_breakpoints': 'delete',
-            'breakpoint': 'break'}
+            'breakpoint': 'break'
+        }

--- a/rplugin/python3/gdb/backend/lldb.py
+++ b/rplugin/python3/gdb/backend/lldb.py
@@ -6,6 +6,7 @@ from gdb.parser import Parser
 
 class LldbParser(Parser):
     '''LLDB parser and FSM.'''
+
     def __init__(self, common, cursor, win):
         super().__init__(common, cursor, win)
 
@@ -27,10 +28,9 @@ class LldbParser(Parser):
 
         self.state = self.running
 
-
-def init():
-    '''Initialize the backend.'''
-    return {'initParser': LldbParser,
+        self.command_map = {
+            'initParser': LldbParser,
             'delete_breakpoints': 'breakpoint delete',
             'breakpoint': 'b',
-            'until {}': 'thread until {}'}
+            'until {}': 'thread until {}'
+        }

--- a/rplugin/python3/gdb/backend/pdb.py
+++ b/rplugin/python3/gdb/backend/pdb.py
@@ -6,6 +6,7 @@ from gdb.parser import Parser
 
 class PdbParser(Parser):
     '''PDB parser and FSM.'''
+
     def __init__(self, common, cursor, backend):
         super().__init__(common, cursor, backend)
         self.add_trans(self.paused,
@@ -16,11 +17,9 @@ class PdbParser(Parser):
                        self._query_b)
         self.state = self.paused
 
-
-def init():
-    '''Initialize the backend.'''
-    return {'initParser': PdbParser,
+        self.command_map = {
             'delete_breakpoints': 'clear',
             'breakpoint': 'break',
             'finish': 'return',
-            'print {}': 'print({})'}
+            'print {}': 'print({})'
+        }


### PR DESCRIPTION
Debugging nvim-gdb can be quite confusing given that you can't actually
attach a debugger to it since it runs as part of the neovim runtime.
Implicit runtime behavior makes it more difficult. This patch simply
changes one specific behavior to be more explicit.