### PR TITLE
Introduce Debugger class to handle all the debugger specific responsibilities

### DIFF
--- a/rplugin/python3/gdb/app.py
+++ b/rplugin/python3/gdb/app.py
@@ -4,6 +4,7 @@ import importlib
 from gdb.common import Common
 from gdb.cursor import Cursor
 from gdb.client import Client
+from gdb.debugger import Debugger
 from gdb.win import Win
 from gdb.keymaps import Keymaps
 from gdb.proxy import Proxy
@@ -56,6 +57,8 @@ class App(Common):
 
         # Initialize the parser
         self.parser = self.backend["initParser"](common, self.cursor, self.win)
+
+        self.debugger = Debugger(common, self.parser, self.client)
 
         # Set initial keymaps in the terminal window.
         self.keymaps.dispatch_set_t()
@@ -118,8 +121,7 @@ class App(Common):
 
         if breaks:
             # There already is a breakpoint on this line: remove
-            del_br = self._get_command('delete_breakpoints')
-            self.client.send_line(f"{del_br} {breaks[-1]}")
+            self.debugger.delete_breakpoint(breaks[-1])
         else:
             set_br = self._get_command('breakpoint')
             self.client.send_line(f"{set_br} {file_name}:{line_nr}")

--- a/rplugin/python3/gdb/debugger.py
+++ b/rplugin/python3/gdb/debugger.py
@@ -1,0 +1,22 @@
+'''Base class for all debugger specific responsibilities.'''
+
+
+from gdb.common import Common
+
+
+class Debugger(Common):
+    '''Base class for all debugger specific responsibilities.'''
+
+    def __init__(self, common, parser, client):
+        super().__init__(common)
+        self.parser = parser
+        self.client = client
+
+    def configure_parser(self):
+        '''The method to override to configure the parser'''
+
+    def delete_breakpoint(self, breakp):
+        '''By default, this simply sends a line of text to the debugger.
+        Override this in a subclass to provide more integrated functionality'''
+        del_br = self.parser.command_map["delete_breakpoints"]
+        self.client.send_line(f"{del_br} {breakp}")


### PR DESCRIPTION
Introduce a class that should own the Parsing behavior and the client
communication behaviors. This way all the debugger varaint behavior
is abstracted away to one class and in one file (aside from the
necessary startup scripts).