### PR TITLE
Add a regex to remove ansi color in the parser and enable color in lldb

### DIFF
--- a/lib/lldb_wrap.sh
+++ b/lib/lldb_wrap.sh
@@ -42,4 +42,4 @@ cleanup()
 trap cleanup EXIT
 
 # Execute lldb finally with our custom initialization script
-"$lldb" --no-use-colors -S "$lldb_init" "$@"
+"$lldb" -S "$lldb_init" "$@"


### PR DESCRIPTION
lldb emits colorized text via standard ansi escape sequences e.g.

    \033[31mColored text\033[0mNon-colored text.

This patch adds a parser that strips these sequences on all text piped
from neovim's terminal to gdb so that the user can have colorized text