### PR TITLE
Add type hints to a large chunk of the codebase

### DIFF
--- a/autoload/nvimgdb/ui.vim
+++ b/autoload/nvimgdb/ui.vim
@@ -25,6 +25,7 @@ function! s:UndefCommands()
   delcommand GdbFinish
   delcommand GdbFrameUp
   delcommand GdbFrameDown
+  delcommand GdbFrame
   delcommand GdbInterrupt
   delcommand GdbEvalWord
   delcommand GdbEvalRange
@@ -41,6 +42,7 @@ function! s:DefineCommands()
   command! GdbStep call GdbSend('s')
   command! GdbFinish call GdbSend('finish')
   command! GdbFrameUp call GdbSend('up')
+  command! GdbFrame call GdbSend('frame')
   command! GdbFrameDown call GdbSend('down')
   command! GdbInterrupt call GdbSend()
   command! GdbEvalWord call GdbSend('print {}', expand('<cword>'))

--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -98,8 +98,10 @@ Section 2: Commands                                          *NvimgdbCommands*
 
                                                                  *:GdbFrameUp*
                                                                *:GdbFrameDown*
+                                                                   *:GdbFrame*
 :GdbFrameUp             Navigate up/down one stack frame
 :GdbFrameDown
+:GdbFrame               Move the cursor to the current frame
 
                                                                *:GdbInterrupt*
 :GdbInterrupt          Break program execution into the debugger

--- a/rplugin/python3/gdb/backend/bashdb.py
+++ b/rplugin/python3/gdb/backend/bashdb.py
@@ -1,13 +1,17 @@
 '''BashDB specifics.'''
 
 import re
+
 from gdb.parser import Parser
+from gdb.common import Common
+from gdb.cursor import Cursor
+from gdb.win import Win
 
 
 class BashDBParser(Parser):
     '''BashDB FSM.'''
 
-    def __init__(self, common, cursor, win):
+    def __init__(self, common: Common, cursor: Cursor, win: Win):
         super().__init__(common, cursor, win)
 
         re_jump = re.compile(r'[\r\n]\(([^:]+):(\d+)\):(?=[\r\n])')

--- a/rplugin/python3/gdb/backend/bashdb.py
+++ b/rplugin/python3/gdb/backend/bashdb.py
@@ -20,7 +20,8 @@ class BashDBParser(Parser):
 
         self.command_map = {
             'delete_breakpoints': 'delete',
-            'breakpoint': 'break'
+            'breakpoint': 'break',
+            'frame': 'frame 0'
         }
 
     def _handle_terminated(self, _):

--- a/rplugin/python3/gdb/backend/gdb.py
+++ b/rplugin/python3/gdb/backend/gdb.py
@@ -27,5 +27,6 @@ class GdbParser(Parser):
 
         self.command_map = {
             'delete_breakpoints': 'delete',
-            'breakpoint': 'break'
+            'breakpoint': 'break',
+            'frame': 'frame'
         }

--- a/rplugin/python3/gdb/backend/gdb.py
+++ b/rplugin/python3/gdb/backend/gdb.py
@@ -1,13 +1,17 @@
 '''GDB specifics.'''
 
 import re
+
 from gdb.parser import Parser
+from gdb.common import Common
+from gdb.cursor import Cursor
+from gdb.win import Win
 
 
 class GdbParser(Parser):
     '''GDB parser and FSM.'''
 
-    def __init__(self, common, cursor, win):
+    def __init__(self, common: Common, cursor: Cursor, win: Win):
         super().__init__(common, cursor, win)
 
         re_prompt = re.compile(r'\x1a\x1a\x1a$')

--- a/rplugin/python3/gdb/backend/lldb.py
+++ b/rplugin/python3/gdb/backend/lldb.py
@@ -2,12 +2,15 @@
 
 import re
 from gdb.parser import Parser
+from gdb.common import Common
+from gdb.cursor import Cursor
+from gdb.win import Win
 
 
 class LldbParser(Parser):
     '''LLDB parser and FSM.'''
 
-    def __init__(self, common, cursor, win):
+    def __init__(self, common: Common, cursor: Cursor, win: Win):
         super().__init__(common, cursor, win)
 
         re_prompt = re.compile(r'\s\(lldb\) $')

--- a/rplugin/python3/gdb/backend/lldb.py
+++ b/rplugin/python3/gdb/backend/lldb.py
@@ -32,5 +32,6 @@ class LldbParser(Parser):
             'initParser': LldbParser,
             'delete_breakpoints': 'breakpoint delete',
             'breakpoint': 'b',
-            'until {}': 'thread until {}'
+            'until {}': 'thread until {}',
+            'frame' : 'frame select'
         }

--- a/rplugin/python3/gdb/backend/pdb.py
+++ b/rplugin/python3/gdb/backend/pdb.py
@@ -21,5 +21,6 @@ class PdbParser(Parser):
             'delete_breakpoints': 'clear',
             'breakpoint': 'break',
             'finish': 'return',
-            'print {}': 'print({})'
+            'print {}': 'print({})',
+            'frame': 'list .'
         }

--- a/rplugin/python3/gdb/backend/pdb.py
+++ b/rplugin/python3/gdb/backend/pdb.py
@@ -1,14 +1,18 @@
 '''PDB specifics.'''
 
 import re
+
+from gdb.common import Common
+from gdb.cursor import Cursor
 from gdb.parser import Parser
+from gdb.win import Win
 
 
 class PdbParser(Parser):
     '''PDB parser and FSM.'''
 
-    def __init__(self, common, cursor, backend):
-        super().__init__(common, cursor, backend)
+    def __init__(self, common: Common, cursor: Cursor, win: Win):
+        super().__init__(common, cursor, win)
         self.add_trans(self.paused,
                        re.compile(r'[\r\n]> ([^(]+)\((\d+)\)[^(]+\(\)'),
                        self._paused_jump)

--- a/rplugin/python3/gdb/breakpoint.py
+++ b/rplugin/python3/gdb/breakpoint.py
@@ -1,15 +1,20 @@
 '''.'''
 
 import json
+from typing import Dict, List
+
 from gdb.common import Common
+from gdb.proxy import Proxy
 
 
 class Breakpoint(Common):
     '''Handle breakpoint signs.'''
-    def __init__(self, common, proxy):
+
+    def __init__(self, common: Common, proxy: Proxy):
         super().__init__(common)
         self.proxy = proxy
-        self.breaks = {}    # {file -> {line -> [id]}}
+        # {file -> {line -> [id]}}
+        self.breaks: Dict[str, Dict[str, List[str]]] = {}
         self.max_sign_id = 0
 
     def clear_signs(self):
@@ -18,13 +23,13 @@ class Breakpoint(Common):
             self.vim.call('sign_unplace', 'NvimGdb', {'id': i})
         self.max_sign_id = 0
 
-    def _set_signs(self, buf):
+    def _set_signs(self, buf: int):
         if buf != -1:
             sign_id = 5000 - 1
             # Breakpoints need full path to the buffer (at least in lldb)
-            bpath = self.vim.call("expand", f'#{buf}:p')
+            bpath: str = self.vim.call("expand", f'#{buf}:p')
 
-            def _get_sign_name(count):
+            def _get_sign_name(count: int):
                 max_count = len(self.config.get('sign_breakpoint'))
                 idx = count if count < max_count else max_count - 1
                 return f"GdbBreakpoint{idx}"
@@ -33,17 +38,17 @@ class Breakpoint(Common):
                 sign_id += 1
                 sign_name = _get_sign_name(len(ids))
                 self.vim.call('sign_place', sign_id, 'NvimGdb', sign_name, buf,
-                        {'lnum': line, 'priority': 10})
+                              {'lnum': line, 'priority': 10})
             self.max_sign_id = sign_id
 
-    def query(self, buf_num, fname):
+    def query(self, buf_num: int, fname: str):
         '''Query actual breakpoints for the given file.'''
         self.breaks[fname] = {}
         resp = self.proxy.query(f"info-breakpoints {fname}\n")
         if resp:
             # We expect the proxies to send breakpoints for a given file
             # as a map of lines to array of breakpoint ids set in those lines.
-            breaks = json.loads(resp)
+            breaks: Dict[str, List[str]] = json.loads(resp)
             err = breaks.get('_error', None)
             if err:
                 self.vim.command(f"echo \"Can't get breakpoints: {err}\"")
@@ -57,7 +62,7 @@ class Breakpoint(Common):
         self.breaks = {}
         self.clear_signs()
 
-    def get_for_file(self, fname, line):
+    def get_for_file(self, fname: str, line: int):
         '''Get breakpoints for the given position in a file.'''
-        breaks = self.breaks.get(fname, {})
+        breaks: Dict[str, List[str]] = self.breaks.get(fname, {})
         return breaks.get(f"{line}", {})   # make sure the line is a string

--- a/rplugin/python3/gdb/client.py
+++ b/rplugin/python3/gdb/client.py
@@ -1,6 +1,10 @@
 '''.'''
 
 import os
+from typing import Optional
+
+import pynvim
+
 from gdb.common import Common
 from gdb.sockdir import SockDir
 
@@ -14,10 +18,10 @@ class Client(Common):
             path = os.path.dirname(path)
         return path
 
-    def __init__(self, common, win, proxy_cmd, client_cmd):
+    def __init__(self, common: Common, win: pynvim.api.Window, proxy_cmd: str, client_cmd: str):
         super().__init__(common)
         self.win = win
-        self.client_id = None
+        self.client_id: Optional[int] = None
         # Create a temporary unique directory for all the sockets.
         self.sock_dir = SockDir()
 
@@ -64,7 +68,7 @@ class Client(Common):
         '''Execute one command on the debugger interpreter.'''
         self.vim.call("jobsend", self.client_id, data + "\n")
 
-    def get_buf(self):
+    def get_buf(self) -> pynvim.api.Buffer:
         '''Get the client terminal buffer.'''
         return self.client_buf
 

--- a/rplugin/python3/gdb/config.py
+++ b/rplugin/python3/gdb/config.py
@@ -3,8 +3,9 @@
 
 import copy
 import re
-from gdb.keymaps import Keymaps
+
 from gdb.common import Common
+from gdb.keymaps import Keymaps
 
 
 class Config(Common):
@@ -30,9 +31,9 @@ class Config(Common):
                             '●⁹', '●ⁿ'],
         'split_command': 'split',
         'set_scroll_off': 5
-        }
+    }
 
-    def __init__(self, common):
+    def __init__(self, common: Common):
         '''Prepare actual configuration with overrides resolved.'''
         super().__init__(common)
 
@@ -116,7 +117,7 @@ class Config(Common):
     def _define_signs(self):
         # Define the sign for current line the debugged program is executing.
         self.vim.call('sign_define', 'GdbCurrentLine',
-                {'text': self.config["sign_current_line"]})
+                      {'text': self.config["sign_current_line"]})
         # Define signs for the breakpoints.
         breaks = self.config["sign_breakpoint"]
         for i, brk in enumerate(breaks):

--- a/rplugin/python3/gdb/config.py
+++ b/rplugin/python3/gdb/config.py
@@ -20,6 +20,7 @@ class Config(Common):
         'key_breakpoint': '<f8>',
         'key_frameup': '<c-p>',
         'key_framedown': '<c-n>',
+        'key_frame': '<c-`>',
         'key_eval': '<f9>',
         'set_tkeymaps': Keymaps.set_t,
         'set_keymaps': Keymaps.set,

--- a/rplugin/python3/gdb/cursor.py
+++ b/rplugin/python3/gdb/cursor.py
@@ -5,7 +5,8 @@ from gdb.common import Common
 
 class Cursor(Common):
     '''The current line sign operations.'''
-    def __init__(self, common):
+
+    def __init__(self, common: Common):
         super().__init__(common)
         self.buf = -1
         self.line = -1
@@ -23,7 +24,7 @@ class Cursor(Common):
         # To avoid flicker when removing/adding the sign column(due to
         # the change in line width), we switch ids for the line sign
         # and only remove the old line sign after marking the new one.
-        old_sign_id = self.sign_id
+        old_sign_id: int = self.sign_id
         self.sign_id = 4999 + (4998 - old_sign_id if old_sign_id != -1 else 0)
         if self.line != -1 and self.buf != -1:
             self.vim.call('sign_place', self.sign_id, 'NvimGdb',
@@ -33,7 +34,7 @@ class Cursor(Common):
             self.vim.call('sign_unplace', 'NvimGdb',
                           {'id': old_sign_id, 'buffer': self.buf})
 
-    def set(self, buf, line):
+    def set(self, buf: int, line: int):
         '''Set the current line sign number.'''
         self.buf = buf
         self.line = int(line)

--- a/rplugin/python3/gdb/keymaps.py
+++ b/rplugin/python3/gdb/keymaps.py
@@ -7,6 +7,7 @@ from gdb.common import Common
 
 class Keymaps(Common):
     '''Keymaps manager.'''
+
     def __init__(self, common):
         super().__init__(common)
         self.dispatch_active = True

--- a/rplugin/python3/gdb/keymaps.py
+++ b/rplugin/python3/gdb/keymaps.py
@@ -24,6 +24,7 @@ class Keymaps(Common):
         ('n', 'key_breakpoint', ':GdbBreakpointToggle'),
         ('n', 'key_frameup', ':GdbFrameUp'),
         ('n', 'key_framedown', ':GdbFrameDown'),
+        ('n', 'key_frame', ':GdbFrame'),
         ('n', 'key_eval', ':GdbEvalWord'),
         ('v', 'key_eval', ':GdbEvalRange'),
     }

--- a/rplugin/python3/gdb/logger.py
+++ b/rplugin/python3/gdb/logger.py
@@ -5,6 +5,7 @@ import os
 
 class Logger:
     '''The logger configurable with environment variables.'''
+
     def __init__(self):
         fname = os.getenv('NVIMGDB_LOGFILE')
         self.fout = None if not fname else open(fname, 'w')

--- a/rplugin/python3/gdb/parser.py
+++ b/rplugin/python3/gdb/parser.py
@@ -1,41 +1,43 @@
 '''State machine for handing debugger output.'''
 
 from gdb.common import Common
-
+from gdb.cursor import Cursor
+from gdb.win import Win
+from typing import List, Optional, Tuple, Pattern, AnyStr, Callable
 
 class Parser(Common):
     '''Common FSM implementation for the integrated backends.'''
-    def __init__(self, common, cursor, win):
+    def __init__(self, common: Common, cursor: Cursor, win: Win):
         super().__init__(common)
         self.cursor = cursor
         self.win = win
-        self.running = []  # The running state [(matcher, matchingFunc)]
-        self.paused = []   # The paused state [(matcher, matchingFunc)]
-        self.state = None  # Current state (either self.running or self.paused)
+        self.running: List[Tuple[Pattern[AnyStr], Callable]] = []  # The running state [(matcher, matchingFunc)]
+        self.paused: List[Tuple[Pattern[AnyStr], Callable]] = []   # The paused state [(matcher, matchingFunc)]
+        self.state: Optional[List[Tuple[Pattern[AnyStr], Callable]]] = None  # Current state (either self.running or self.paused)
         self.buffer = '\n'
 
     @staticmethod
-    def add_trans(state, matcher, func):
+    def add_trans(state: Optional[List[Tuple[Pattern[AnyStr], Callable]]], matcher: Pattern[AnyStr], func: Callable):
         '''Add a new transition for a given state using {matcher, matchingFunc}
            Call the handler when matched.'''
         state.append((matcher, func))
 
-    def is_paused(self):
+    def is_paused(self) -> bool:
         '''Test whether the FSM is in the paused state.'''
         return self.state == self.paused
 
-    def is_running(self):
+    def is_running(self) -> bool:
         '''Test whether the FSM is in the running state.'''
         return self.state == self.running
 
-    def _get_state_name(self):
+    def _get_state_name(self) -> str:
         if self.state == self.running:
             return "running"
         if self.state == self.paused:
             return "paused"
         return str(self.state)
 
-    def _paused_continue(self, _):
+    def _paused_continue(self, _) -> List[Tuple[Pattern[AnyStr], Callable]]:
         self.log("_paused_continue")
         self.cursor.hide()
 
@@ -43,7 +45,7 @@ class Parser(Common):
 
         return self.running
 
-    def _paused_jump(self, match):
+    def _paused_jump(self, match) -> List[Tuple[Pattern[AnyStr], Callable]]:
         fname = match.group(1)
         line = match.group(2)
         self.log(f"_paused_jump {fname}:{line}")
@@ -53,7 +55,7 @@ class Parser(Common):
 
         return self.paused
 
-    def _query_b(self, _):
+    def _query_b(self, _) -> List[Tuple[Pattern[AnyStr], Callable]]:
         self.log('_query_b')
         self.win.query_breakpoints()
 
@@ -62,7 +64,7 @@ class Parser(Common):
 
         return self.paused
 
-    def _search(self):
+    def _search(self) -> bool:
         # If there is a matcher matching the line, call its handler.
         for matcher, func in self.state:
             match = matcher.search(self.buffer)
@@ -73,7 +75,7 @@ class Parser(Common):
                 return True
         return False
 
-    def feed(self, lines):
+    def feed(self, lines: List[str]):
         '''Process a line of the debugger output through the FSM.'''
         for line in lines:
             self.log(line)

--- a/rplugin/python3/gdb/proxy.py
+++ b/rplugin/python3/gdb/proxy.py
@@ -38,7 +38,7 @@ class Proxy(Common):
                                  f" to the proxy: {msg}'")
         return self.connected
 
-    def query(self, request):
+    def query(self, request) -> str:
         '''Send a request to the proxy and wait for the response.'''
         # It takes time for the proxy to open a side channel.
         # So we're connecting to the socket lazily during

--- a/rplugin/python3/gdb/sockdir.py
+++ b/rplugin/python3/gdb/sockdir.py
@@ -1,12 +1,13 @@
 '''.'''
 
 import tempfile
+from typing import Optional
 
 
 class SockDir:
     '''Unique directory for the rendez-vous point.'''
     def __init__(self):
-        self.sock_dir = tempfile.TemporaryDirectory(prefix='nvimgdb-sock')
+        self.sock_dir: Optional[tempfile.TemporaryDirectory] = tempfile.TemporaryDirectory(prefix='nvimgdb-sock')
 
     def cleanup(self):
         '''The destructor.'''

--- a/rplugin/python3/gdb/win.py
+++ b/rplugin/python3/gdb/win.py
@@ -1,11 +1,20 @@
 '''.'''
 
+from typing import Dict, Optional, Union
+
+import pynvim
+
+from gdb.breakpoint import Breakpoint
+from gdb.client import Client
 from gdb.common import Common
+from gdb.cursor import Cursor
+from gdb.keymaps import Keymaps
 
 
 class Win(Common):
     '''Jump window management.'''
-    def __init__(self, common, win, cursor, client, break_point, keymaps):
+
+    def __init__(self, common: Common, win: pynvim.api.Window, cursor: Cursor, client: Client, break_point: Breakpoint, keymaps: Keymaps):
         super().__init__(common)
         # window number that will be displaying the current file
         self.jump_win = win
@@ -14,15 +23,15 @@ class Win(Common):
         self.breakpoint = break_point
         self.keymaps = keymaps
 
-    def is_jump_window_active(self):
+    def is_jump_window_active(self) -> bool:
         '''Check whether the current buffer is displayed in the jump window.'''
         return self.vim.current.buffer == self.jump_win.buffer
 
-    def jump(self, file, line):
+    def jump(self, file: str, line: int):
         '''Show the file and the current line in the jump window.'''
         self.log(f"jump({file}:{line})")
         # Check whether the file is already loaded or load it
-        target_buf = self.vim.call("bufnr", file, 1)
+        target_buf: int = self.vim.call("bufnr", file, 1)
 
         # The terminal buffer may contain the name of the source file
         # (in pdb, for instance).
@@ -40,8 +49,8 @@ class Win(Common):
                 self.keymaps.set_dispatch_active(True)
 
         if self.jump_win.buffer.handle != target_buf:
-            mode = self.vim.api.get_mode()
-            prev_window = None
+            mode: Dict[str, Union[bool, str, int]] = self.vim.api.get_mode()
+            prev_window: Optional[pynvim.api.Window] = None
             if self.jump_win != self.vim.current.window:
                 prev_window = self.vim.current.window
                 self.vim.current.window = self.jump_win
@@ -61,10 +70,10 @@ class Win(Common):
     def query_breakpoints(self):
         '''Show actual breakpoints in the current window.'''
         # Get the source code buffer number
-        buf_num = self.jump_win.buffer.handle
+        buf_num: int = self.jump_win.buffer.handle
 
         # Get the source code file name
-        fname = self.vim.call("expand", f'#{buf_num}:p')
+        fname: str = self.vim.call("expand", f'#{buf_num}:p')
 
         # If no file name or a weird name with spaces, ignore it (to avoid
         # misinterpretation)


### PR DESCRIPTION
Figuring out somebody elses codebase is much easier when you can rely
on your tools to tell you what a type is and what it does. This change
enables autocompletion and go-to defintion/usage for much of the
codebase.
