### PR TITLE
revert back to the old lldb implementation

### DIFF
--- a/lib/lldb_wrap.sh
+++ b/lib/lldb_wrap.sh
@@ -26,6 +26,8 @@ this_dir=$(readlinkf "$(dirname "${BASH_SOURCE[0]}")")
 lldb_init=$(mktemp /tmp/lldb_init.XXXXXX)
 cat >"$lldb_init" <<EOF
 command script import $this_dir/lldb_commands.py
+command script add -f lldb_commands.init nvim-gdb-init
+nvim-gdb-init $server_addr
 settings set frame-format frame #\${frame.index}: \${frame.pc}{ \${module.file.basename}{\`\${function.name-with-args}{\${frame.no-debug}\${function.pc-offset}}}}{ at \032\032\${line.file.fullpath}:\${line.number}}{\${function.is-optimized} [opt]}\n
 settings set auto-confirm true
 settings set stop-line-count-before 0
@@ -35,8 +37,9 @@ EOF
 cleanup()
 {
     unlink "$lldb_init"
+    unlink "$server_addr"
 }
 trap cleanup EXIT
 
-# Execute lldb finally through the proxy with our custom initialization script
-"$this_dir/lldb_proxy.py" -a "$server_addr" -- "$lldb" -S "$lldb_init" "$@"
+# Execute lldb finally with our custom initialization script
+"$lldb" -S "$lldb_init" "$@"

--- a/rplugin/python3/gdb/backend/lldb.py
+++ b/rplugin/python3/gdb/backend/lldb.py
@@ -11,7 +11,7 @@ class _ParserImpl(parser_impl.ParserImpl):
     def __init__(self, common, handler):
         super().__init__(common, handler)
 
-        re_prompt = re.compile(r'\s\(lldb\) (\(lldb\) )?$')
+        re_prompt = re.compile(r'\s\(lldb\) $')
         self.add_trans(self.paused,
                        re.compile(r'Process \d+ resuming'),
                        self._paused_continue)
@@ -30,11 +30,11 @@ class _ParserImpl(parser_impl.ParserImpl):
 class _BreakpointImpl(base.BaseBreakpoint):
     def __init__(self, proxy):
         self.proxy = proxy
-        self.logger = logging.getLogger("Lldb.Breakpoint")
+        self.logger = logging.getLogger("Gdb.Breakpoint")
 
     def query(self, fname: str):
         self.logger.info("Query breakpoints for %s", fname)
-        resp = self.proxy.query(f"handle-command nvim-gdb-info-breakpoints {fname}")
+        resp = self.proxy.query(f"info-breakpoints {fname}\n")
         if not resp:
             return {}
         # LLDB may mess the input (like space + back space).


### PR DESCRIPTION
You can use `debugger.GetID()` to uniquely identify a debugger and
`lldb.SBDebugger_FindDebuggerWithID(id)` to get it later in a different
context. This allows us to restore the old implementation.

This is ideal because the current lldb proxy doesn't correctly handle
input all the time. Isolating the exact issue is difficult, but many
keys entries can trigger an erasure of the entire line as well as
frequent clobbering of history.