### PR TITLE
Set buffer filetype to 'nvimgdb'

### DIFF
--- a/rplugin/python3/gdb/client.py
+++ b/rplugin/python3/gdb/client.py
@@ -53,6 +53,7 @@ class Client(Common):
         self.vim.current.window = self.win
         self.client_id = self.vim.call("nvimgdb#TermOpen", self.command,
                                        self.vim.current.tabpage.handle)
+        self.vim.command("set filetype=nvimgdb")
         # Allow detaching the terminal from its window
         self.vim.command("set bufhidden=hide")
         # Finsih the debugging session when the terminal is closed


### PR DESCRIPTION
Note that the terminal buffer doesn't provide a filetype, it would be better to set the filetype of debug buffer to 'nvimgdb'. This option allows user to customize the style of the debug window using `autocmd FileType nvimgdb` or `ftplugin/nvimgdb.vim`.

