### PR TITLE
Allow configuring jumping to bottom of gdb buffer

### DIFF
--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -193,6 +193,8 @@ allows overriding the given keys. For example, the default config is: >
       \ 'sign_breakpoint': [ '●', '●²', '●³', '●⁴', '●⁵', '●⁶', '●⁷', '●⁸', '●⁹', '●ⁿ' ],
       \ 'sign_breakpoint_priority': 10,
       \ 'codewin_command': 'new'
+      \ 'set_scroll_off': 5,
+      \ 'jump_bottom_gdb_buf': v:true,
       \ }
 <
 The key `codewin_command` defines a Vim command to create a new empty window
@@ -225,6 +227,9 @@ very specific terminal keymaps.  The keys `set_keymaps` and `unset_keymaps`
 are called every time when the source code windows is entered and left.  The
 first one can be used to define source window-specific keymaps and the latter
 to carefully cleanup them.  See `test/init.vim` for an example.
+
+The key `jump_bottom_gdb_buf` enables jumping to the bottom of the gdb terminal
+buffer when focus is moved to a different window.
 
 Finally, every configuration key can be overridden with a global variable
 prefixed `g:nvimgdb_`.  For example, `g:nvimgdb_key_next` overrides

--- a/lua/nvimgdb/app.lua
+++ b/lua/nvimgdb/app.lua
@@ -234,7 +234,10 @@ end
 function C:on_buf_leave()
   if vim.bo.buftype == 'terminal' then
     -- Move the cursor to the end of the buffer
-    vim.cmd("$")
+    local jump_bottom = self.config:get_or('jump_bottom_gdb_buf', false)
+    if jump_bottom then
+      vim.cmd("$")
+    end
     return
   end
   if self.win:is_jump_window_active() then

--- a/lua/nvimgdb/config.lua
+++ b/lua/nvimgdb/config.lua
@@ -28,6 +28,7 @@ local default = {
   sign_breakpoint_priority = 10,
   codewin_command     = 'new',
   set_scroll_off      = 5,
+  jump_bottom_gdb_buf = true,
 }
 
 -- Turn a string into a funcref looking up a Vim function.


### PR DESCRIPTION
Personally, I find this behavior annoying. I left it on by default, but when missing from the config it is set to false.