### PR TITLE
Editor is out sync with GDB Breakpoint hits - cursor is not positioned to hit line

### DIFF
--- a/rplugin/python3/gdb/backend/gdb.py
+++ b/rplugin/python3/gdb/backend/gdb.py
@@ -25,6 +25,9 @@ class _ParserImpl(parser_impl.ParserImpl):
         self.add_trans(self.running,
                        re.compile(r'\sBreakpoint \d+'),
                        self._query_b)
+        self.add_trans(self.running,
+                       re.compile(r'\sTemporary breakpoint \d+'),
+                       self._query_b)
         self.add_trans(self.running, re_prompt, self._query_b)
         self.add_trans(self.running, re_jump, self._paused_jump)
 

--- a/rplugin/python3/gdb/backend/gdb.py
+++ b/rplugin/python3/gdb/backend/gdb.py
@@ -23,7 +23,7 @@ class _ParserImpl(parser_impl.ParserImpl):
         self.add_trans(self.paused, re_jump, self._paused_jump)
         self.add_trans(self.paused, re_prompt, self._query_b)
         self.add_trans(self.running,
-                       re.compile(r'[\r\n]Breakpoint \d+'),
+                       re.compile(r'\sBreakpoint \d+'),
                        self._query_b)
         self.add_trans(self.running, re_prompt, self._query_b)
         self.add_trans(self.running, re_jump, self._paused_jump)


### PR DESCRIPTION
Fixed: Editor is out sync with Breakpoint hits - cursor is not auto positioned to hit line.

Breakpoint hit may not start with new line as on example:

	Thread 1 "wrc_proc_test1" hit Breakpoint 2

Added support of gdb temp breakpoints

gdb version 9.2