### PR TITLE
fix(gdb_wrap): make prompt.hook keep original position

### DIFF
--- a/lib/gdb_wrap.sh
+++ b/lib/gdb_wrap.sh
@@ -28,7 +28,7 @@ cat >"$gdb_init" <<EOF
 set confirm off
 set pagination off
 set filename-display absolute
-python gdb.prompt_hook = lambda p: p + ("" if p.endswith("\x1a\x1a\x1a") else "\x1a\x1a\x1a")
+python gdb.prompt_hook = lambda p: p + ("" if p.endswith("\x01\x1a\x1a\x1a\x02") else "\x01\x1a\x1a\x1a\x02")
 EOF
 
 cleanup()


### PR DESCRIPTION
Press `<c-p>` sometimes make the prompt broken, I don't know why until I `set prompt \033[34mgdb \033[0m` in `.gdbinit` and run gdb without nvim-gdb also found this issue.

And then someone provides me below information, I change `set prompt \001\033[34m\002gdb \001\033[0m\002` to solve 
 this issue successfully in native gdb.

It looks like also works with `prompt.hook`.

I'm not sure this works on macOS, I only test on Linux, BTW, the tests are hung.....

FYI: 
https://stackoverflow.com/questions/9468435/how-to-fix-column-calculation-in-python-readline-if-using-color-prompt/9468954#9468954