### PR TITLE
fix(win.lua): avoid unnecessary WinEnter event

### DIFF
--- a/lua/nvimgdb/win.lua
+++ b/lua/nvimgdb/win.lua
@@ -187,7 +187,7 @@ function C:jump(file, line)
 
   -- Goto the proper line and set the cursor on it
   self:_with_saved_win(false, function()
-    vim.api.nvim_set_current_win(self.jump_win)
+    NvimGdb.vim.cmd(string.format("noa call nvim_set_current_win(%d)", self.jump_win))
     vim.api.nvim_win_set_cursor(self.jump_win, {line, 0})
     self.cursor:set(target_buf, line)
     self.cursor:show()


### PR DESCRIPTION
Some gdb's instructions will fire jump win action which will jump between the code window and the term window.

It's unnecessary to fire redundant WinEnter event which makes the status line Dithering.