### PR TITLE
fix(win.lua): should unset keymap for buffer after nvim-gdb is closed

### DIFF
--- a/lua/nvimgdb.lua
+++ b/lua/nvimgdb.lua
@@ -100,6 +100,7 @@ function NvimGdb.cleanup(tab)
         log.info("Calling nvimgdb#GlobalCleanup()")
         NvimGdb.vim.fn["nvimgdb#GlobalCleanup"]()
         NvimGdb.efmmgr.cleanup()
+        app.win:unset_keymaps()
       end
       app:cleanup(tab)
     end)

--- a/lua/nvimgdb/win.lua
+++ b/lua/nvimgdb/win.lua
@@ -199,6 +199,7 @@ function C:jump(file, line)
     NvimGdb.vim.cmd("normal! zv")
   end)
   NvimGdb.vim.cmd("redraw")
+  self.buffers[target_buf] = true
 end
 
 -- Test whether an item is in the list

--- a/lua/nvimgdb/win.lua
+++ b/lua/nvimgdb/win.lua
@@ -45,6 +45,16 @@ function C.new(config, keymaps, cursor, client, breakpoint, start_win, edited_bu
   return self
 end
 
+-- Only make sense if nvimgdb#GlobalCleanup is called
+function C:unset_keymaps()
+  if self:_has_jump_win() then
+    self:_with_saved_win(true, function()
+      vim.api.nvim_set_current_win(self.jump_win)
+      pcall(self.keymaps.dispatch_unset, self.keymaps)
+    end)
+  end
+end
+
 -- Cleanup the windows and buffers.
 function C:cleanup()
   for buf, _ in pairs(self.buffers) do
@@ -199,7 +209,6 @@ function C:jump(file, line)
     NvimGdb.vim.cmd("normal! zv")
   end)
   NvimGdb.vim.cmd("redraw")
-  self.buffers[target_buf] = true
 end
 
 -- Test whether an item is in the list


### PR DESCRIPTION
Without recording after jumping window, buffer may not be cleaned. (keymaps)