### PR TITLE
refactor(win): nvim_get_current_win is already a window handle

### DIFF
--- a/lua/nvimgdb/win.lua
+++ b/lua/nvimgdb/win.lua
@@ -124,8 +124,7 @@ function C:_ensure_jump_window()
 end
 
 local function adjust_jump_win_view(jump_win, line, scroll_off)
-  local winid = vim.fn.win_getid(vim.api.nvim_win_get_number(jump_win))
-  local wininfo = vim.fn.getwininfo(winid)[1]
+  local wininfo = vim.fn.getwininfo(jump_win)[1]
   local botline = wininfo.botline
   local topline = wininfo.topline
 

--- a/test/test_10_generic.py
+++ b/test/test_10_generic.py
@@ -146,8 +146,7 @@ def test_scrolloff(eng, backend):
 
     def _check_margin():
         jump_win = eng.exec_lua('return NvimGdb.i().win.jump_win')
-        wininfo = eng.eval(
-            f"getwininfo(win_getid(nvim_win_get_number({jump_win})))[0]")
+        wininfo = eng.eval(f"getwininfo({jump_win})[0]")
         curline = eng.eval(f"nvim_win_get_cursor({jump_win})[0]")
         signline = int(eng.get_signs()['cur'].split(':')[1])
         assert signline == curline


### PR DESCRIPTION
Remove redundant win_getid(nvim_win_get_number(win_handle))