### PR TITLE
Better way to enter insert mode

### DIFF
--- a/lua/nvimgdb/app.lua
+++ b/lua/nvimgdb/app.lua
@@ -89,8 +89,8 @@ function C:postinit()
   self.client:start()
   NvimGdb.vim.cmd("doautocmd User NvimGdbStart")
 
-  -- Start insert mode in the GDB window
-  vim.fn.feedkeys("i")
+  -- Start insert mode in the debugger window
+  vim.cmd("startinsert")
   -- Set initial keymaps in the terminal window.
   assert(vim.api.nvim_get_current_win() == self.client.win)
   self.keymaps:dispatch_set_t()


### PR DESCRIPTION
The way insert mode is currently entered doesn't work well if `nvim` is already configured to enter insert mode on `TermOpen`.
(for example if you have `autocmd TermOpen * startinsert` in your vim init script)

If the terminal starts already in insert mode then the `vim.fn.feedkeys("i")` will feed the 'i' character to the gdb/lldb command prompt (that is an invalid command).

Using `vim.cmd("startinsert")` doesn't trigger the problem:
- If we are not in insert mode then insert mode is entered
- If we are already in insert mode then nothing happens