### PR TITLE
Do not list debug buffer

### DIFF
--- a/lua/nvimgdb/client.lua
+++ b/lua/nvimgdb/client.lua
@@ -70,6 +70,8 @@ function C:start()
   vim.bo.filetype = "nvimgdb"
   -- Allow detaching the terminal from its window
   vim.bo.bufhidden = "hide"
+  -- Prevent the debugger buffer from being listed
+  vim.bo.buflisted = false
   -- Finish the debugging session when the terminal is closed
   -- Left the remains of the code intentionally to remind that there is no need
   -- to close the debugger terminal automatically.


### PR DESCRIPTION
This PR prevents the terminal buffer - used to display the debugger console - from being listed along with the other buffers (i.e. using `ls` or `buffers` command).

Motivations
1. prevent switching into the debug buffer while examining decode in the sources window (e.g. because of a `bnext` command).
2. don't show the debug buffer in tools showing the opened buffers list (e.g. lualine).

AFAIK this is a "standard" approach used by other tools such as `nvim-tree`, `tagbar`, etc.
