### PR TITLE
Make the terminal window sticky

### DIFF
--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -249,13 +249,6 @@ are called every time when the source code windows is entered and left.  The
 first one can be used to define source window-specific keymaps and the latter
 to carefully cleanup them.  See `test/keymap_hooks.vim` for an example.
 
-The key `jump_bottom_gdb_buf` enables jumping to the bottom of the gdb terminal
-buffer when focus is moved to a different window.
-
-The key `sticky_gdb_buf` makes the debugger terminal always shown in a window.
-Setting it to true (default) will make sure to restore the terminal window
-with `termwin_command` if it's accidentally or intentially closed.
-
 Finally, every configuration key can be overridden with a global variable
 prefixed `g:nvimgdb_`.  For example, `g:nvimgdb_key_next` overrides
 `g:nvimgdb_config["key_next"]` etc.
@@ -298,6 +291,13 @@ window, try the following: >
 <
 If there is a debugging session already running on the current tabpage, a new
 debugging session will be created on a separate tabpage.
+
+The key `sticky_gdb_buf` makes the debugger terminal always shown in a window.
+Setting it to true (default) will make sure to restore the terminal window
+with `termwin_command` if it's accidentally or intentially closed.
+
+The key `jump_bottom_gdb_buf` enables jumping to the bottom of the gdb terminal
+buffer when focus is moved to a different window.
 
 ==============================================================================
 Section 5: Events                                              *NvimgdbEvents*

--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -252,6 +252,10 @@ to carefully cleanup them.  See `test/keymap_hooks.vim` for an example.
 The key `jump_bottom_gdb_buf` enables jumping to the bottom of the gdb terminal
 buffer when focus is moved to a different window.
 
+The key `sticky_gdb_buf` makes the debugger terminal always shown in a window.
+Setting it to true (default) will make sure to restore the terminal window
+with `termwin_command` if it's accidentally or intentially closed.
+
 Finally, every configuration key can be overridden with a global variable
 prefixed `g:nvimgdb_`.  For example, `g:nvimgdb_key_next` overrides
 `g:nvimgdb_config["key_next"]` etc.

--- a/doc/nvimgdb.txt
+++ b/doc/nvimgdb.txt
@@ -292,7 +292,7 @@ window, try the following: >
 If there is a debugging session already running on the current tabpage, a new
 debugging session will be created on a separate tabpage.
 
-The key `sticky_gdb_buf` makes the debugger terminal always shown in a window.
+The key `sticky_dbg_buf` makes the debugger terminal always shown in a window.
 Setting it to true (default) will make sure to restore the terminal window
 with `termwin_command` if it's accidentally or intentially closed.
 

--- a/lua/nvimgdb/client.lua
+++ b/lua/nvimgdb/client.lua
@@ -97,12 +97,15 @@ end
 -- Make the debugger window sticky. If closed accidentally,
 -- resurrect it.
 function C:_check_sticky()
-  local prev_win = vim.api.nvim_get_current_win()
-  NvimGdb.vim.cmd(self.config:get('termwin_command'))
-  local buf = vim.api.nvim_get_current_buf()
-  NvimGdb.vim.cmd('b ' .. self.client_buf)
-  vim.api.nvim_buf_delete(buf, {})
-  vim.api.nvim_set_current_win(prev_win)
+  local sticky = self.config:get_or('sticky_gdb_buf', true)
+  if sticky then
+    local prev_win = vim.api.nvim_get_current_win()
+    NvimGdb.vim.cmd(self.config:get('termwin_command'))
+    local buf = vim.api.nvim_get_current_buf()
+    NvimGdb.vim.cmd('b ' .. self.client_buf)
+    vim.api.nvim_buf_delete(buf, {})
+    vim.api.nvim_set_current_win(prev_win)
+  end
 end
 
 -- Interrupt running program by sending ^c.

--- a/lua/nvimgdb/client.lua
+++ b/lua/nvimgdb/client.lua
@@ -91,7 +91,7 @@ function C:start()
   --vim.cmd("au TermClose <buffer> lua NvimGdb.cleanup(" .. cur_tabpage .. ")")
 
   -- Check whether the terminal buffer should always be shown
-  local sticky = self.config:get_or('sticky_gdb_buf', true)
+  local sticky = self.config:get_or('sticky_dbg_buf', true)
   if sticky then
     self.buf_hiddend_auid = vim.api.nvim_create_autocmd("BufHidden", {
       buffer = self.client_buf,

--- a/lua/nvimgdb/config.lua
+++ b/lua/nvimgdb/config.lua
@@ -30,6 +30,7 @@ local default = {
   codewin_command     = 'new',             -- Assign a window for the source code
   set_scroll_off      = 5,
   jump_bottom_gdb_buf = true,
+  sticky_gdb_buf = true,
 }
 
 -- Turn a string into a funcref looking up a Vim function.

--- a/lua/nvimgdb/config.lua
+++ b/lua/nvimgdb/config.lua
@@ -30,7 +30,7 @@ local default = {
   codewin_command     = 'new',             -- Assign a window for the source code
   set_scroll_off      = 5,
   jump_bottom_gdb_buf = true,
-  sticky_gdb_buf = true,
+  sticky_dbg_buf      = true,
 }
 
 -- Turn a string into a funcref looking up a Vim function.

--- a/test/engine.py
+++ b/test/engine.py
@@ -39,7 +39,7 @@ class Engine:
         # Builds on GitHub seem to be more prone to races.
         is_github = os.environ.get('GITHUB_WORKFLOW')
         self.feed_delay = 0.02 if not is_github else 0.5
-        self.launch_delay = 3000 if not is_github else 20000
+        self.launch_delay = 5000 if not is_github else 20000
 
     def close(self):
         '''Close.'''

--- a/test/test_05_quit.py
+++ b/test/test_05_quit.py
@@ -23,6 +23,12 @@ def test_gdb_debug_stop(setup, eng):
     eng.feed(":GdbDebugStop<cr>")
 
 
+def test_gdb_eof(setup, eng):
+    '''Quit with ctrl-d.'''
+    assert setup
+    eng.feed("i<c-d>")
+
+
 def test_gdb_tabclose(setup, eng):
     '''Quit by closing the tab.'''
     assert setup

--- a/test/test_05_quit.py
+++ b/test/test_05_quit.py
@@ -30,3 +30,30 @@ def test_gdb_tabclose(setup, eng):
     eng.feed('<esc>')
     eng.feed(":tabclose<cr>")
     eng.feed(":GdbDebugStop<cr>")
+
+
+def test_sticky_term(setup, eng):
+    '''GDB terminal survives closing.'''
+    assert setup
+    assert 2 == len(eng.eval("nvim_list_wins()"))
+    eng.feed(":q<cr>")
+    assert 2 == len(eng.eval("nvim_list_wins()"))
+    eng.feed(":GdbDebugStop<cr>")
+
+
+@pytest.fixture(scope='function')
+def non_sticky(eng):
+    '''The fixture to disable terminal stickiness.'''
+    eng.feed(":let g:nvimgdb_sticky_gdb_buf = v:false<cr>")
+    yield True
+    eng.feed(":unlet g:nvimgdb_sticky_gdb_buf<cr>")
+
+
+def test_elusive_term(non_sticky, setup, eng):
+    '''GDB terminal can be closed.'''
+    assert non_sticky
+    assert setup
+    assert 2 == len(eng.eval("nvim_list_wins()"))
+    eng.feed(":q<cr>")
+    assert 1 == len(eng.eval("nvim_list_wins()"))
+    eng.feed(":GdbDebugStop<cr>")

--- a/test/test_05_quit.py
+++ b/test/test_05_quit.py
@@ -50,9 +50,9 @@ def test_sticky_term(setup, eng):
 @pytest.fixture(scope='function')
 def non_sticky(eng):
     '''The fixture to disable terminal stickiness.'''
-    eng.feed(":let g:nvimgdb_sticky_gdb_buf = v:false<cr>")
+    eng.feed(":let g:nvimgdb_sticky_dbg_buf = v:false<cr>")
     yield True
-    eng.feed(":unlet g:nvimgdb_sticky_gdb_buf<cr>")
+    eng.feed(":unlet g:nvimgdb_sticky_dbg_buf<cr>")
 
 
 def test_elusive_term(non_sticky, setup, eng):

--- a/test/test_70_quickfix.py
+++ b/test/test_70_quickfix.py
@@ -45,8 +45,6 @@ def test_bt_backend(eng, backend):
     assert eng.eval("line('.')") == 12
     eng.feed(':lnext\n')
     assert eng.eval("line('.')") == 19
-    eng.feed(':lnext\n')
-    assert eng.eval("line('.')") == 19
 
 
 def test_breaks_pdb(eng, post):


### PR DESCRIPTION
Ensure the terminal window is always shown unless `sticky_gdb_buf` is set to `false` in the configuration.
This addresses #171 