### PR TITLE
rr replay: ensure helper script runs in python3

### DIFF
--- a/lib/rr-replay.py
+++ b/lib/rr-replay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import asyncio
 import pipes


### PR DESCRIPTION
`rr replay` is launched via a helper script written in Python.
This script must be run by Python v3; it is not compatible with
Python v2. Use `python3` in the shebang line so that `python2`
isn't called on systems where `python` is a link to `python2`.
See Python PEP 394.