### PR TITLE
Enter insert mode when entering the debugger terminal

### DIFF
--- a/lua/nvimgdb/app.lua
+++ b/lua/nvimgdb/app.lua
@@ -248,6 +248,8 @@ function C:on_buf_enter()
     self.keymaps:dispatch_set()
     -- Ensure breakpoints are shown if are queried dynamically
     self.win:query_breakpoints()
+  else
+    vim.cmd("startinsert!")
   end
 end
 


### PR DESCRIPTION
When moving to the terminal window is better to enter insert mode to immediately start writing stuff on the debugger prompt.