### PR TITLE
fix(185): Wrap buf_del_keymap in pcall()

### DIFF
--- a/lua/nvimgdb/app.lua
+++ b/lua/nvimgdb/app.lua
@@ -237,8 +237,6 @@ function App:on_tab_enter()
   if self.parser:is_paused() then
     self.cursor:show()
   end
-  -- Just in case that OnBufEnter isn't fired. Thus, multiple on_buf_enter() calls may occur.
-  self:on_buf_enter()
 end
 
 -- Actions to execute when a tabpage is left.
@@ -247,8 +245,6 @@ function App:on_tab_leave()
   -- Hide the signs
   self.cursor:hide()
   self.breakpoint:clear_signs()
-  -- If the same buffer is focused on the other tabpage, OnBufLeave wouldn't be fired.
-  self:on_buf_leave()
 end
 
 -- Actions to execute when a buffer is entered.

--- a/lua/nvimgdb/app.lua
+++ b/lua/nvimgdb/app.lua
@@ -237,6 +237,8 @@ function App:on_tab_enter()
   if self.parser:is_paused() then
     self.cursor:show()
   end
+  -- Just in case that OnBufEnter isn't fired. Thus, multiple on_buf_enter() calls may occur.
+  self:on_buf_enter()
 end
 
 -- Actions to execute when a tabpage is left.
@@ -245,6 +247,8 @@ function App:on_tab_leave()
   -- Hide the signs
   self.cursor:hide()
   self.breakpoint:clear_signs()
+  -- If the same buffer is focused on the other tabpage, OnBufLeave wouldn't be fired.
+  self:on_buf_leave()
 end
 
 -- Actions to execute when a buffer is entered.

--- a/lua/nvimgdb/keymaps.lua
+++ b/lua/nvimgdb/keymaps.lua
@@ -63,7 +63,7 @@ function Keymaps:unset()
   for _, m in ipairs(default) do
     local keystroke = self.config:get(m.key)
     if keystroke ~= nil then
-      vim.api.nvim_buf_del_keymap(vim.api.nvim_get_current_buf(), m.mode, keystroke)
+      pcall(vim.api.nvim_buf_del_keymap(vim.api.nvim_get_current_buf(), m.mode, keystroke))
     end
   end
 end

--- a/lua/nvimgdb/keymaps.lua
+++ b/lua/nvimgdb/keymaps.lua
@@ -63,7 +63,7 @@ function Keymaps:unset()
   for _, m in ipairs(default) do
     local keystroke = self.config:get(m.key)
     if keystroke ~= nil then
-      pcall(vim.api.nvim_buf_del_keymap(vim.api.nvim_get_current_buf(), m.mode, keystroke))
+      pcall(vim.api.nvim_buf_del_keymap, vim.api.nvim_get_current_buf(), m.mode, keystroke)
     end
   end
 end


### PR DESCRIPTION
Wraps buf_del_keymap in pcall(), fixing #185 .