### PR TITLE
Don't force temp files to be created in /tmp

### DIFF
--- a/lib/gdb_wrap.sh
+++ b/lib/gdb_wrap.sh
@@ -27,7 +27,7 @@ fi
 # the rest are gdb arguments
 shift
 
-gdb_init=$(mktemp /tmp/gdb_init.XXXXXX)
+gdb_init=$(mktemp --tmpdir gdb_init.XXXXXX)
 cat >"$gdb_init" <<EOF
 set confirm off
 set pagination off

--- a/lib/gdb_wrap.sh
+++ b/lib/gdb_wrap.sh
@@ -27,7 +27,7 @@ fi
 # the rest are gdb arguments
 shift
 
-gdb_init=$(mktemp --tmpdir gdb_init.XXXXXX)
+gdb_init=$(mktemp -t gdb_init.XXXXXX)
 cat >"$gdb_init" <<EOF
 set confirm off
 set pagination off

--- a/lib/lldb_wrap.sh
+++ b/lib/lldb_wrap.sh
@@ -23,7 +23,7 @@ shift
 readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
 this_dir=$(readlinkf "$(dirname "${BASH_SOURCE[0]}")")
 
-lldb_init=$(mktemp /tmp/lldb_init.XXXXXX)
+lldb_init=$(mktemp --tmpdir lldb_init.XXXXXX)
 cat >"$lldb_init" <<EOF
 command script import $this_dir/lldb_commands.py
 command script add -f lldb_commands.init nvim-gdb-init

--- a/lib/lldb_wrap.sh
+++ b/lib/lldb_wrap.sh
@@ -23,7 +23,7 @@ shift
 readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
 this_dir=$(readlinkf "$(dirname "${BASH_SOURCE[0]}")")
 
-lldb_init=$(mktemp --tmpdir lldb_init.XXXXXX)
+lldb_init=$(mktemp -t lldb_init.XXXXXX)
 cat >"$lldb_init" <<EOF
 command script import $this_dir/lldb_commands.py
 command script add -f lldb_commands.init nvim-gdb-init

--- a/test/all.sh
+++ b/test/all.sh
@@ -5,7 +5,7 @@ rootDir="$(pwd -P)"
 
 # Deliberately test that the tests pass from a random symlink
 # to the source directory.
-tmpDir="$(mktemp -d /tmp/nvim-gdb-test.XXXXXX)"
+tmpDir="$(mktemp -d --tmpdir nvim-gdb-test.XXXXXX)"
 ln -sf "$rootDir" "$tmpDir/src"
 cleanup() {
     unlink "$tmpDir/src";

--- a/test/all.sh
+++ b/test/all.sh
@@ -5,7 +5,7 @@ rootDir="$(pwd -P)"
 
 # Deliberately test that the tests pass from a random symlink
 # to the source directory.
-tmpDir="$(mktemp -d --tmpdir nvim-gdb-test.XXXXXX)"
+tmpDir="$(mktemp -d -t nvim-gdb-test.XXXXXX)"
 ln -sf "$rootDir" "$tmpDir/src"
 cleanup() {
     unlink "$tmpDir/src";


### PR DESCRIPTION
On some platforms, like termux on android, `/tmp` is inaccessible. If we remove the `/tmp` prefix on the templates and instead set the `--tmpdir` flag, `mktemp` will use `$TMPDIR`, which on termux is set to `/data/data/com.termux/files/usr/tmp`

On my debian box where `TMPDIR` is unset it falls back to `/tmp`.

From the manpage:

```
> -p DIR, --tmpdir[=DIR]
>   interpret TEMPLATE relative to DIR; if DIR is not specified, use
>   $TMPDIR if set, else /tmp.
```

BTW, the code that handles this is here: http://git.savannah.gnu.org/cgit/coreutils.git/tree/src/mktemp.c#n286