### PR TITLE
Use full, resolved paths from gdb

### DIFF
--- a/lib/gdb_commands.py
+++ b/lib/gdb_commands.py
@@ -125,7 +125,7 @@ class NvimGdbInit(gdb.Command):
             if frame is not None:
                 symtab_and_line = frame.find_sal()
                 if symtab_and_line.symtab is not None:
-                    filename = symtab_and_line.symtab.filename
+                    filename = symtab_and_line.symtab.fullname()
                     line = symtab_and_line.line
                     return [filename, line]
         except gdb.error:


### PR DESCRIPTION
This change gives us paths after path substitution in gdb. With that we're able to jump to correct symbols more often in nvim. Especially when debugging code from system libraries.