### PR TITLE
Fix older gdb breakpoints parse bugs

### DIFF
--- a/test/10_generic_spec.lua
+++ b/test/10_generic_spec.lua
@@ -31,7 +31,13 @@ describe("generic", function()
 
         local function check_signs(signs)
           -- different for different compilers
-          return vim.deep_equal(signs, {cur = 'test.cpp:17'}) or vim.deep_equal(signs, {cur = 'test.cpp:19'})
+          local lines = {17, 19, 20}
+          for _, line in ipairs(lines) do
+            if vim.deep_equal(signs, {cur = 'test.cpp:' .. line}) then
+              return true
+            end
+          end
+          return false
         end
         assert.is_true(eng.wait_for(eng.get_signs, check_signs))
 
@@ -70,7 +76,7 @@ describe("generic", function()
         eng.feed('<esc>')
         assert.is_true(eng.wait_running(5000))
         eng.feed(':GdbInterrupt\n')
-        if not utils.is_windows then
+        if utils.is_linux then
           assert.is_true(eng.wait_signs({cur = 'test.cpp:22'}))
         else
           -- Most likely to break in the kernel code
@@ -180,7 +186,22 @@ describe("generic", function()
         eng.feed('n<cr>')
         assert.is_true(eng.wait_signs({cur = 'test.cpp:19'}))
         eng.feed('<cr>')
-        assert.is_true(eng.wait_signs({cur = 'test.cpp:17'}))
+
+        if utils.is_darwin then
+          local function check_signs(signs)
+            -- different for different compilers
+            local lines = {17, 20}
+            for _, line in ipairs(lines) do
+              if vim.deep_equal(signs, {cur = 'test.cpp:' .. line}) then
+                return true
+              end
+            end
+            return false
+          end
+          assert.is_true(eng.wait_for(eng.get_signs, check_signs))
+        else
+          assert.is_true(eng.wait_signs({cur = 'test.cpp:17'}))
+        end
       end)
     end)
 

--- a/test/all.py
+++ b/test/all.py
@@ -36,6 +36,8 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     Prerequisites()
 
     test_cmd = ["nvim", "-l", "run-tests.lua", ".", "--no-keep-going"]
+    # Use the following command to see neovim screen
+    # test_cmd = ["python", "nvim.py", "+luafile main.lua"]
     print(f"Run `{' '.join(test_cmd)}`")
     res = subprocess.run(test_cmd)
     if res.returncode != 0:

--- a/utils/testenv_darwin.py
+++ b/utils/testenv_darwin.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 import urllib.request
 
@@ -16,14 +17,17 @@ class Setup:
 
         subprocess.run('pip install --user six', shell=True, check=True)
 
-        urllib.request.urlretrieve(f"{url}/nvim-macos.tar.gz",
-                                   "nvim-macos.tar.gz")
+        # Macos may be running on arm64
+        machine = platform.machine()
+
+        urllib.request.urlretrieve(f"{url}/nvim-macos-{machine}.tar.gz",
+                                   f"nvim-macos-{machine}.tar.gz")
         subprocess.run(
-            r'''
-tar -xf nvim-macos.tar.gz
+            f'''
+tar -xf nvim-macos-{machine}.tar.gz
 cat >"$HOME/bin/nvim" <<EOF
 #!/bin/bash
-$(pwd)/nvim-macos/bin/nvim "\$@"
+$(pwd)/nvim-macos-{machine}/bin/nvim "\\$@"
 EOF
 chmod +x "$HOME/bin/nvim"
             ''',


### PR DESCRIPTION
When encountered <MULTIPLE> breakpoint in gdb output  as following, parser will not consider Ena as "y".

```
Num     Type           Disp Enb Address            What
1       breakpoint     keep y   <MULTIPLE>         
1.1                         y   0xffff800080d90414 in __arch_counter_get_cntvct at ./arch/arm64/include/asm/arch_timer.h:204
1.2                         y   0xffff800081014f10 in __arch_counter_get_cntvct at ./arch/arm64/include/asm/arch_timer.h:204
```