### PR TITLE
Update rr-replay.py to work with rr 5.8.0

### DIFF
--- a/lib/rr-replay.py
+++ b/lib/rr-replay.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import asyncio
-import pipes
 import sys
 import shlex
+import re
 
 # rr replay refuses to run outside of a pty. But it allows
 # attaching a gdb remotely.
@@ -33,9 +33,11 @@ async def run(cmd):
         cmd,
         stderr=asyncio.subprocess.PIPE)
 
+    header_regex = re.compile(b'Launch \\w+ with$')
+
     # Check it launched
     header = await rr_proc.stderr.readline()
-    if header != b'Launch debugger with\n':
+    if not header_regex.match(header):
         rest = await rr_proc.stderr.read()
         raise RuntimeError(f"Unexpected: {header.decode()}{rest.decode()}")
 


### PR DESCRIPTION
Notice that the `GdbStartRR` was not working, so I fixed it. But it appears it have stopped working just in the last version (https://github.com/rr-debugger/rr/commit/07d2aeb7e7a7e9b632681107f4f75602a5362060), so I am not sure if you would like to break support from all previous versions to address this.

I don't have time to make a more generalized fix, but here is with a have done.