### PR TITLE
Don't jump to source after commands that don't progress the program

### DIFF
--- a/lib/gdb_commands.py
+++ b/lib/gdb_commands.py
@@ -29,16 +29,17 @@ class NvimGdbInit(gdb.Command):
         self.thrd = None
         self.fallback_to_parsing = False
         self.state = "stopped"
-        self.exited = False
+        self.exited_or_ran = False
 
         def handle_continue(event):
             self.state = "running"
+            self.exited_or_ran = True
         gdb.events.cont.connect(handle_continue)
         def handle_stop(event):
             self.state = "stopped"
         def handle_exit(event):
             self.state = "stopped"
-            self.exited = True
+            self.exited_or_ran = True
         gdb.events.stop.connect(handle_stop)
         gdb.events.exited.connect(handle_exit)
 
@@ -88,8 +89,8 @@ class NvimGdbInit(gdb.Command):
         elif request == "get-current-frame-location":
             self._send_response(self._get_current_frame_location(),
                                 req_id, sock, addr)
-        elif request == "has-exited":
-            self._send_response(self._get_exited(),
+        elif request == "has-exited-or-ran":
+            self._send_response(self._get_reset_exited_or_ran(),
                                 req_id, sock, addr)
         elif request == "handle-command":
             # pylint: disable=broad-except
@@ -126,9 +127,9 @@ class NvimGdbInit(gdb.Command):
     def _get_process_state(self):
         return self.state
 
-    def _get_exited(self):
-        if (self.exited):
-            self.exited = False
+    def _get_reset_exited_or_ran(self):
+        if (self.exited_or_ran):
+            self.exited_or_ran = False
             return True
         return False
 

--- a/lua/nvimgdb/backend/gdb.lua
+++ b/lua/nvimgdb/backend/gdb.lua
@@ -44,7 +44,7 @@ function C.create_parser(actions, proxy)
           local fname = location[1]
           local line = location[2]
           if (fname ~= self.prev_fname or line ~= self.prev_line) or
-              proxy:query('has-exited') then
+              proxy:query('has-exited-or-ran') then
             self.prev_line = line
             self.prev_fname = fname
             self.actions:jump_to_source(fname, line)

--- a/lua/nvimgdb/backend/gdb.lua
+++ b/lua/nvimgdb/backend/gdb.lua
@@ -29,6 +29,9 @@ function C.create_parser(actions, proxy)
   local self = setmetatable({}, P)
   self:_init(actions)
 
+  P.prev_fname = nil
+  P.prev_line = nil
+
   function P:query_paused()
     log.debug({"P:query_paused"})
     coroutine.resume(coroutine.create(function()
@@ -40,7 +43,11 @@ function C.create_parser(actions, proxy)
         if #location == 2 then
           local fname = location[1]
           local line = location[2]
-          self.actions:jump_to_source(fname, line)
+          if (fname ~= self.prev_fname or line ~= self.prev_line) then
+            self.prev_line = line
+            self.prev_fname = fname
+            self.actions:jump_to_source(fname, line)
+          end
         end
       end
       self.actions:query_breakpoints()

--- a/lua/nvimgdb/backend/gdb.lua
+++ b/lua/nvimgdb/backend/gdb.lua
@@ -43,7 +43,8 @@ function C.create_parser(actions, proxy)
         if #location == 2 then
           local fname = location[1]
           local line = location[2]
-          if (fname ~= self.prev_fname or line ~= self.prev_line) then
+          if (fname ~= self.prev_fname or line ~= self.prev_line) or
+              proxy:query('has-exited') then
             self.prev_line = line
             self.prev_fname = fname
             self.actions:jump_to_source(fname, line)


### PR DESCRIPTION
Currently (using gdb), typing a command like `p foo` will cause the program to jump to the source even thought the program hasn't progressed so it will jump to the same place each time. This is annoying when you want to print out a series of variable and you keep being taken out of the gdb terminal.

This PR stops this occurring by recording the previous filename + line we jumped to and only jumping if we are jumping somewhere else.

I have only implemented this for GDB (since it'' the only debugger I use). If there is interest in this PR, I can implement for the others.